### PR TITLE
Add Label text number of lines of the button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -130,6 +130,10 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * Specifies the largest possible scale a text font can reach.
    */
   maxFontSizeMultiplier?: number;
+  /**
+   * Label text number Of Lines of the button.
+   */
+  noOfLines?: number;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
    * Style for the button text.
@@ -186,6 +190,7 @@ const Button = (
     onPressOut,
     onLongPress,
     delayLongPress,
+    noOfLines,
     style,
     theme: themeOverrides,
     uppercase: uppercaseProp,
@@ -266,6 +271,7 @@ const Button = (
 
   const borderRadius = (isV3 ? 5 : 1) * roundness;
   const iconSize = isV3 ? 18 : 16;
+  const numberOfLines = noOfLines ? 1 : noOfLines;
 
   const { backgroundColor, borderColor, textColor, borderWidth } =
     getButtonColors({
@@ -383,7 +389,7 @@ const Button = (
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             testID={`${testID}-text`}
             style={[
               styles.label,


### PR DESCRIPTION
A pull request for the react-native-paper repository maximum number of lines displayed in the label text of buttons. 

**Key Takeaways:**

A pull request was created for the react-native-paper repository.
The pull request includes changes to Button.tsx files.
The pull request is mergeable.

- Add option for number of lines for label text.